### PR TITLE
Add build dep on cmake_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(octomap_ros)
 
-find_package(catkin REQUIRED COMPONENTS sensor_msgs tf octomap_msgs)
+find_package(catkin REQUIRED COMPONENTS cmake_modules sensor_msgs tf octomap_msgs)
 find_package(octomap REQUIRED)
 
 catkin_package(

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   
   <build_depend>catkin</build_depend>
+  <build_depend>cmake_modules</build_depend>
   <build_depend>octomap_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
The cmake module shipped with the octomap package uses absolute paths
that break cross-compilation builds and require additional tweaking
(e.g. see https://github.com/bmwcarit/meta-ros/blob/43bd17e8839f4078351895eca361804f19efb13c/recipes-ros/octomap-ros/octomap-ros_0.4.0.bb#L16)

This patch makes octomap_ros use the cmake module provided by ROS's
cmake_modules package to avoid such tweaks.

The patch depends on https://github.com/ros/cmake_modules/pull/43