### PR TITLE
Fix catkin_lint issues and cmake policy CMP0038

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,28 @@
 cmake_minimum_required(VERSION 2.8)
 project(octomap_ros)
 
-find_package(catkin REQUIRED COMPONENTS sensor_msgs tf octomap_msgs)
-find_package(octomap REQUIRED)
+find_package(catkin REQUIRED COMPONENTS octomap_msgs sensor_msgs tf)
+find_package(OCTOMAP REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include ${OCTOMAP_INCLUDE_DIRS}
-  LIBRARIES ${PROJECT_NAME} ${OCTOMAP_LIBRARIES}
-  DEPENDS sensor_msgs tf octomap_msgs)
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS octomap_msgs sensor_msgs tf
+  DEPENDS OCTOMAP)
 
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
-link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
-
-include_directories(${OCTOMAP_INCLUDE_DIRS})
-link_directories(${OCTOMAP_LIBRARY_DIRS})
-link_libraries(${PROJECT_NAME} ${OCTOMAP_LIBRARIES})
-
-include_directories(include)
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME} src/conversions.cpp)
+add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${OCTOMAP_LIBRARIES})
+target_include_directories(${PROJECT_NAME}
+  SYSTEM PUBLIC ${catkin_INCLUDE_DIRS} ${OCTOMAP_INCLUDE_DIRS}
+  PUBLIC include)
 
-install(TARGETS ${PROJECT_NAME} 
+install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 
-install(DIRECTORY include/octomap_ros/
-  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/octomap_ros/
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE)

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   
   <buildtool_depend>catkin</buildtool_depend>
   
-  <build_depend>catkin</build_depend>
   <build_depend>octomap_msgs</build_depend>
   <build_depend>octomap</build_depend>
   <build_depend>sensor_msgs</build_depend>


### PR DESCRIPTION
Fixes #8.

Some changes are due to how `find_package` actually sets the variables (see [here](https://github.com/OctoMap/octomap/blob/devel/octomap/octomap-config.cmake.in)) but the rest only comes from catkin_lint.