### PR TITLE
Switch to using the rosdep liboctomap-dev key.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <depend>octomap</depend>
+  <depend>liboctomap-dev</depend>
   <depend>octomap_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>


### PR DESCRIPTION
That is, instead of taking this dependency from the ROS distribution, take it from the system.  This is to ensure that we use a consistent ABI with the
platform-provided liboctomap.

Note that in the near future, we'll be removing the ROS-provided octomap in favor of only using the
system-provided one.

This has been enabled by https://github.com/ros/rosdistro/pull/41623, and should be backported to Rolling, Jazzy, Iron, and Humble.